### PR TITLE
feat(internationalization): added multilanguage support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [1.0.3] - 2025-07-06
+### Added
+- Multilanguage support
+- Locale Resolver (Accept-Language header)
+- GraphQL custom fetcher exception handling
+
 ## [1.0.2] - 2025-07-03
 ### Added
 - GraphQL support

--- a/README.md
+++ b/README.md
@@ -16,6 +16,13 @@ At this link you can also find the documentation for the API.
 
 ## API
 
+Tagger provides both REST and GraphQL APIs for generating tags, titles, and descriptions for various items. The API is designed to be flexible and easy to use, allowing you to generate content for different platforms and audiences.
+
+Tagger supports multilanguage generation. To change language, you can set the `Accept-Language` header in your request.
+The default language is English (`en`), but you can use any other language that is supported by the OpenAI API.
+
+Error messages are available only in english and polish.
+
 ---
 
 ## REST

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 	</parent>
 	<groupId>pl.sgorski</groupId>
 	<artifactId>Tagger</artifactId>
-	<version>1.0.2</version>
+	<version>1.0.3</version>
 	<name>Tagger</name>
 	<description>Tags, description and title creator.</description>
 	<developers>

--- a/src/main/java/pl/sgorski/Tagger/config/LocaleConfiguration.java
+++ b/src/main/java/pl/sgorski/Tagger/config/LocaleConfiguration.java
@@ -1,0 +1,32 @@
+package pl.sgorski.Tagger.config;
+
+import lombok.extern.log4j.Log4j2;
+import org.springframework.context.MessageSource;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.support.ReloadableResourceBundleMessageSource;
+import org.springframework.web.servlet.LocaleResolver;
+import org.springframework.web.servlet.i18n.AcceptHeaderLocaleResolver;
+
+import java.util.Locale;
+
+@Log4j2
+@Configuration
+public class LocaleConfiguration {
+
+    @Bean
+    public LocaleResolver localeResolver() {
+        log.debug("Creating Locale Resolver bean");
+        AcceptHeaderLocaleResolver slr = new AcceptHeaderLocaleResolver();
+        slr.setDefaultLocale(Locale.forLanguageTag("en-US"));
+        return slr;
+    }
+
+    @Bean
+    public MessageSource messageSource() {
+        ReloadableResourceBundleMessageSource ms = new ReloadableResourceBundleMessageSource();
+        ms.setBasename("classpath:messages");
+        ms.setDefaultEncoding("UTF-8");
+        return ms;
+    }
+}

--- a/src/main/java/pl/sgorski/Tagger/controller/graphql/GraphqlExceptionController.java
+++ b/src/main/java/pl/sgorski/Tagger/controller/graphql/GraphqlExceptionController.java
@@ -1,0 +1,27 @@
+package pl.sgorski.Tagger.controller.graphql;
+
+import graphql.GraphQLError;
+import graphql.GraphqlErrorBuilder;
+import graphql.schema.DataFetchingEnvironment;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.MessageSource;
+import org.springframework.graphql.execution.DataFetcherExceptionResolverAdapter;
+import org.springframework.graphql.execution.ErrorType;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class GraphqlExceptionController extends DataFetcherExceptionResolverAdapter {
+
+    private final MessageSource messageSource;
+
+    @Override
+    protected GraphQLError resolveToSingleError(Throwable ex, DataFetchingEnvironment env) {
+        String message = messageSource.getMessage("error.generic.message", null, env.getLocale());
+        return GraphqlErrorBuilder.newError(env)
+                .message(message + ": " + ex.getMessage())
+                .errorType(ErrorType.INTERNAL_ERROR)
+                .locations(null)
+                .build();
+    }
+}

--- a/src/main/java/pl/sgorski/Tagger/controller/rest/RestExceptionController.java
+++ b/src/main/java/pl/sgorski/Tagger/controller/rest/RestExceptionController.java
@@ -1,6 +1,9 @@
 package pl.sgorski.Tagger.controller.rest;
 
+import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
+import org.springframework.context.MessageSource;
+import org.springframework.context.i18n.LocaleContextHolder;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ProblemDetail;
 import org.springframework.http.converter.HttpMessageNotReadableException;
@@ -11,49 +14,60 @@ import pl.sgorski.Tagger.exception.AiParsingException;
 
 @Log4j2
 @RestControllerAdvice
-public class ExceptionController {
+@RequiredArgsConstructor
+public class RestExceptionController {
+
+    private final MessageSource messageSource;
 
     @ExceptionHandler(HttpMessageNotReadableException.class)
     public ProblemDetail handleInvalidFormatException(HttpMessageNotReadableException e) {
         log.error("Invalid format: {}", e.getMessage(), e);
+        String msg = messageSource.getMessage("error.invalid.format.message", null, LocaleContextHolder.getLocale());
+        String title = messageSource.getMessage("error.invalid.format.title", null, LocaleContextHolder.getLocale());
         ProblemDetail problemDetail = ProblemDetail.forStatusAndDetail(
                 HttpStatus.BAD_REQUEST,
-                "Invalid format: " + e.getMessage()
+                msg + ": " + e.getMessage()
         );
-        problemDetail.setTitle("Invalid Format");
+        problemDetail.setTitle(title);
         return problemDetail;
     }
 
     @ExceptionHandler(BindException.class)
     public ProblemDetail handleValidationException(BindException e) {
         log.error("Validation error: {}", e.getMessage(), e);
+        String msg = messageSource.getMessage("error.validation.message", null, LocaleContextHolder.getLocale());
+        String title = messageSource.getMessage("error.validation.title", null, LocaleContextHolder.getLocale());
         ProblemDetail problemDetail = ProblemDetail.forStatusAndDetail(
                 HttpStatus.CONFLICT,
-                "Validation has failed: " + e.getMessage()
+                msg + ": " + e.getAllErrors().getFirst().getDefaultMessage()
         );
-        problemDetail.setTitle("Not valid data");
+        problemDetail.setTitle(title);
         return problemDetail;
     }
 
     @ExceptionHandler(AiParsingException.class)
     public ProblemDetail handleAiParsingException(AiParsingException e) {
         log.error("Ai parsing error: {}", e.getMessage(), e);
+        String msg = messageSource.getMessage("error.ai.parsing.message", null, LocaleContextHolder.getLocale());
+        String title = messageSource.getMessage("error.ai.parsing.title", null, LocaleContextHolder.getLocale());
         ProblemDetail problemDetail = ProblemDetail.forStatusAndDetail(
                 HttpStatus.BAD_REQUEST,
-                "Parsing has failed: " + e.getMessage()
+                msg + ": " + e.getMessage()
         );
-        problemDetail.setTitle("Could not parse response");
+        problemDetail.setTitle(title);
         return problemDetail;
     }
 
     @ExceptionHandler(Exception.class)
     public ProblemDetail handleException(Exception e) {
         log.error("An error occurred: {}", e.getMessage(), e);
+        String msg = messageSource.getMessage("error.generic.message", null, LocaleContextHolder.getLocale());
+        String title = messageSource.getMessage("error.generic.title", null, LocaleContextHolder.getLocale());
         ProblemDetail problemDetail = ProblemDetail.forStatusAndDetail(
                 HttpStatus.INTERNAL_SERVER_ERROR,
-                e.getMessage()
+                msg + ": " + e.getMessage()
         );
-        problemDetail.setTitle("Unexpected Error");
+        problemDetail.setTitle(title);
         return problemDetail;
     }
 }

--- a/src/main/java/pl/sgorski/Tagger/dto/PromptRequest.java
+++ b/src/main/java/pl/sgorski/Tagger/dto/PromptRequest.java
@@ -9,20 +9,20 @@ import lombok.Data;
 @Data
 public class PromptRequest {
 
-    @NotBlank(message = "Style must be specified")
+    @NotBlank(message = "{validation.style.notBlank}")
     @Schema(description = "Style of the response", examples = {"casual", "formal", "youthful", "elegant", "modern"})
     private String responseStyle;
 
-    @NotBlank(message = "Target audience must be specified")
+    @NotBlank(message = "{validation.target.notBlank}")
     @Schema(description = "Target audience for the product", examples = {"teenagers", "adults", "seniors", "children"})
     private String targetAudience;
 
-    @NotBlank(message = "Item name cannot be blank")
+    @NotBlank(message = "{validation.item.notBlank}")
     @Schema(description = "Name of the item", examples = {"Smartphone", "T-shirt", "Jeans", "iPhone 16e 128GB", "Toyota Corolla 2023"})
     private String item;
 
-    @Min(value = 1, message = "Quantity must be at least 1")
-    @Max(value = 50, message = "Quantity cannot exceed 50")
+    @Min(value = 1, message = "{validation.tags.min}")
+    @Max(value = 50, message = "{validation.tags.max}")
     @Schema(description = "Number of tags to generate", example = "10", defaultValue = "10")
     private int tagsQuantity = 10;
 

--- a/src/main/java/pl/sgorski/Tagger/service/ClothesService.java
+++ b/src/main/java/pl/sgorski/Tagger/service/ClothesService.java
@@ -1,6 +1,8 @@
 package pl.sgorski.Tagger.service;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.MessageSource;
+import org.springframework.context.i18n.LocaleContextHolder;
 import org.springframework.stereotype.Service;
 import pl.sgorski.Tagger.dto.ClothesRequest;
 import pl.sgorski.Tagger.dto.PromptRequest;
@@ -11,13 +13,14 @@ import pl.sgorski.Tagger.dto.PromptResponse;
 public class ClothesService implements ItemsService {
 
     private final AiService aiService;
+    private final MessageSource messageSource;
 
     @Override
     public PromptResponse getFullInfo(PromptRequest request) {
         if (request instanceof ClothesRequest clothesRequest) {
             return aiService.generateResponse(generatePrompt(clothesRequest));
         } else {
-            throw new IllegalArgumentException("Invalid request type. Expected ClothesRequest.");
+            throw new IllegalArgumentException(messageSource.getMessage("exception.illegal.argument",new String[]{"Clothes request"}, LocaleContextHolder.getLocale()));
         }
     }
 
@@ -26,7 +29,7 @@ public class ClothesService implements ItemsService {
         if (request instanceof ClothesRequest clothesRequest) {
             return createClothsPrompt(clothesRequest);
         } else {
-            throw new IllegalArgumentException("Invalid request type. Expected ClothesRequest.");
+            throw new IllegalArgumentException(messageSource.getMessage("exception.illegal.argument",new String[]{"Clothes request"}, LocaleContextHolder.getLocale()));
         }
     }
 

--- a/src/main/java/pl/sgorski/Tagger/service/ElectronicsService.java
+++ b/src/main/java/pl/sgorski/Tagger/service/ElectronicsService.java
@@ -1,6 +1,8 @@
 package pl.sgorski.Tagger.service;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.MessageSource;
+import org.springframework.context.i18n.LocaleContextHolder;
 import org.springframework.stereotype.Service;
 import pl.sgorski.Tagger.dto.ElectronicsRequest;
 import pl.sgorski.Tagger.dto.PromptRequest;
@@ -11,13 +13,14 @@ import pl.sgorski.Tagger.dto.PromptResponse;
 public class ElectronicsService implements ItemsService {
 
     private final AiService aiService;
+    private final MessageSource messageSource;
 
     @Override
     public PromptResponse getFullInfo(PromptRequest request) {
         if (request instanceof ElectronicsRequest electronicsRequest) {
             return aiService.generateResponse(generatePrompt(electronicsRequest));
         } else {
-            throw new IllegalArgumentException("Invalid request type. Expected ElectronicsRequest.");
+            throw new IllegalArgumentException(messageSource.getMessage("exception.illegal.argument",new String[]{"Electronics request"}, LocaleContextHolder.getLocale()));
         }
     }
 
@@ -26,7 +29,7 @@ public class ElectronicsService implements ItemsService {
         if (request instanceof ElectronicsRequest electronicsRequest) {
             return createElectronicsPrompt(electronicsRequest);
         } else {
-            throw new IllegalArgumentException("Invalid request type. Expected ElectronicsRequest.");
+            throw new IllegalArgumentException(messageSource.getMessage("exception.illegal.argument",new String[]{"Electronics request"}, LocaleContextHolder.getLocale()));
         }
     }
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -14,4 +14,4 @@ ai.system.context=You are an AI assistant helping online sellers create attracti
   \ For electronic items (e.g., phone, laptop, TV, dishwasher): if specifications are not provided but you know typical specs for the model, include them in your response. \
   \ Be aware of adding specs if there are many variations of item. \
   \ Adjust your response to the selling platform provided by user. It is very important to match the target audience. \
-  \ Always return only pure JSON, without markdown or backticks.
+  \ Always return only pure JSON, without markdown or backticks. Make sure that every atomic element is a string (in double quotes).

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -1,0 +1,18 @@
+validation.style.notBlank=Style must be specified
+validation.target.notBlank=Target audience must be specified
+validation.item.notBlank=Item name cannot be blank
+validation.tags.min=Tags quantity must be at least {value}
+validation.tags.max=Tags quantity must be at most {value}
+
+error.invalid.format.message=Invalid format
+error.invalid.format.title=Invalid Format
+error.validation.message=Invalid data entered
+error.validation.title=Invalid Data
+error.ai.parsing.message=An error occurred while converting to JSON format
+error.ai.parsing.title=JSON Conversion Error
+error.generic.message=An error occurred
+error.generic.title=Unexpected Error
+
+exception.illegal.argument=Invalid request type. Required: {0}
+exception.ai.parsing=An error occurred during conversion to JSON
+exception.ai.generic=An error occurred while processing the AI request

--- a/src/main/resources/messages_pl.properties
+++ b/src/main/resources/messages_pl.properties
@@ -1,0 +1,18 @@
+validation.style.notBlank=Należy podać styl odpowiedzi
+validation.target.notBlank=Należy podać docelową grupę odbiorców
+validation.item.notBlank=Nalećy zdefiniować przedmiot
+validation.tags.min=Ilość tagów musi wynosić co najmniej {value}
+validation.tags.max=Ilość tagów może wynosić maksymalnie {value}
+
+error.invalid.format.message=Nieprawidłowy format
+error.invalid.format.title=Nieprawidłowy Format
+error.validation.message=Wprowadzono błędne dane
+error.validation.title=Nieprawidłowe Dane
+error.ai.parsing.message=Podczas zmiany formatu na JSON, wystąpił błąd
+error.ai.parsing.title=Błąd zmiany na JSON
+error.generic.message=Wystąpił błąd
+error.generic.title=Nieoczekiwany Błąd
+
+exception.illegal.argument=Nieprawidłowy typ żądania. Wymagane: {0}
+exception.ai.parsing=Wystąpił błąd podczas konwersji na JSON
+exception.ai.generic=Wystąpił błąd podczas przetwarzania żądania SI

--- a/src/test/java/pl/sgorski/Tagger/controller/graphql/PromptResolverTest.java
+++ b/src/test/java/pl/sgorski/Tagger/controller/graphql/PromptResolverTest.java
@@ -1,61 +1,136 @@
 package pl.sgorski.Tagger.controller.graphql;
 
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
-import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.graphql.tester.AutoConfigureGraphQlTester;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.MessageSource;
+import org.springframework.graphql.test.tester.GraphQlTester;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import pl.sgorski.Tagger.dto.ClothesRequest;
 import pl.sgorski.Tagger.dto.ElectronicsRequest;
 import pl.sgorski.Tagger.dto.PromptRequest;
 import pl.sgorski.Tagger.dto.PromptResponse;
+import pl.sgorski.Tagger.exception.AiParsingException;
 import pl.sgorski.Tagger.service.PromptService;
 
-import static org.junit.jupiter.api.Assertions.assertSame;
-import static org.mockito.Mockito.*;
+import java.util.Locale;
 
-@ExtendWith(MockitoExtension.class)
-public class PromptResolverTest {
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.when;
 
-    @Mock
+@SpringBootTest
+@AutoConfigureGraphQlTester
+class PromptResolverTest {
+
+    @Autowired
+    private GraphQlTester graphQlTester;
+
+    @MockitoBean
     private PromptService promptService;
 
-    @InjectMocks
-    private PromptResolver promptResolver;
+    @MockitoBean
+    private MessageSource messageSource;
 
     @Test
     void shouldReturnProductInfo() {
-        PromptRequest request = new PromptRequest();
         PromptResponse response = new PromptResponse();
-        when(promptService.getResponse(request)).thenReturn(response);
+        response.setTitle("Casual T-Shirt");
+        response.setDescription("A comfortable and stylish t-shirt for everyday wear.");
+        response.setTags(new String[]{"#casual", "#t-shirt", "#young adults"});
+        when(promptService.getResponse(any(PromptRequest.class))).thenReturn(response);
 
-        PromptResponse result = promptResolver.getProductInfo(request);
+        String query = """
+            query {
+                generateListing(input: { responseStyle: "casual", item: "t-shirt", targetAudience: "young adults" }) {
+                    title
+                    description
+                    tags
+                }
+            }
+        """;
 
-        assertSame(response, result);
-        verify(promptService, times(1)).getResponse(request);
+        graphQlTester.document(query)
+                .execute()
+                .path("generateListing")
+                .hasValue()
+                .path("generateListing.title")
+                .entity(String.class)
+                .isEqualTo("Casual T-Shirt")
+                .path("generateListing.description")
+                .entity(String.class)
+                .isEqualTo("A comfortable and stylish t-shirt for everyday wear.")
+                .path("generateListing.tags")
+                .entityList(String.class)
+                .containsExactly("#casual", "#t-shirt", "#young adults");
     }
 
     @Test
     void shouldReturnClothesInfo() {
-        ClothesRequest request = new ClothesRequest();
         PromptResponse response = new PromptResponse();
-        when(promptService.getResponse(request)).thenReturn(response);
+        response.setTitle("Casual T-Shirt");
+        when(promptService.getResponse(any(ClothesRequest.class))).thenReturn(response);
 
-        PromptResponse result = promptResolver.getClothesInfo(request);
+        String query = """
+            query {
+                generateListingClothes(input: { responseStyle: "casual", item: "t-shirt", targetAudience: "young adults" }) {
+                    title
+                }
+            }
+        """;
 
-        assertSame(response, result);
-        verify(promptService, times(1)).getResponse(request);
+        graphQlTester.document(query)
+                .execute()
+                .path("generateListingClothes")
+                .hasValue()
+                .path("generateListingClothes.title")
+                .entity(String.class)
+                .isEqualTo("Casual T-Shirt");
     }
 
     @Test
     void shouldReturnElectronicsInfo() {
-        ElectronicsRequest request = new ElectronicsRequest();
         PromptResponse response = new PromptResponse();
-        when(promptService.getResponse(request)).thenReturn(response);
+        response.setTitle("iPhone 16e 128GB");
+        when(promptService.getResponse(any(ElectronicsRequest.class))).thenReturn(response);
 
-        PromptResponse result = promptResolver.getElectronicsInfo(request);
+        String query = """
+            query {
+                generateListingElectronics(input: { responseStyle: "casual", item: "iPhone 16e 128gb", targetAudience: "young adults" }) {
+                    title
+                }
+            }
+        """;
 
-        assertSame(response, result);
-        verify(promptService, times(1)).getResponse(request);
+        graphQlTester.document(query)
+                .execute()
+                .path("generateListingElectronics")
+                .hasValue()
+                .path("generateListingElectronics.title")
+                .entity(String.class)
+                .isEqualTo("iPhone 16e 128GB");
+    }
+
+    @Test
+    void shouldReturnErrorWhenParsingError() {
+        when(promptService.getResponse(any(PromptRequest.class))).thenThrow(new AiParsingException("Parsing error"));
+        when(messageSource.getMessage(anyString(), any(), any(Locale.class))).thenReturn("Parsing error");
+        String query = """
+            query {
+                generateListing(input: { responseStyle: "casual", item: "iPhone 16e 128gb", targetAudience: "young adults" }) {
+                    title
+                }
+            }
+        """;
+
+        graphQlTester.document(query)
+                .execute()
+                .errors()
+                .satisfy(errors -> {
+                    assertEquals(1, errors.size());
+                    assertTrue(errors.getFirst().getMessage().contains("Parsing error"));
+                });
     }
 }

--- a/src/test/java/pl/sgorski/Tagger/controller/rest/PromptControllerTest.java
+++ b/src/test/java/pl/sgorski/Tagger/controller/rest/PromptControllerTest.java
@@ -85,7 +85,8 @@ public class PromptControllerTest {
                     assertEquals(HttpStatus.CONFLICT.value(), problemDetail.getStatus());
                     assertNotNull(problemDetail.getDetail());
                     assertFalse(problemDetail.getDetail().isBlank());
-                    assertEquals("Not valid data", problemDetail.getTitle());
+                    assertNotNull(problemDetail.getTitle());
+                    assertFalse(problemDetail.getTitle().isBlank());
                 });
     }
 
@@ -101,7 +102,8 @@ public class PromptControllerTest {
                     assertEquals(HttpStatus.BAD_REQUEST.value(), problemDetail.getStatus());
                     assertNotNull(problemDetail.getDetail());
                     assertFalse(problemDetail.getDetail().isBlank());
-                    assertEquals("Invalid Format", problemDetail.getTitle());
+                    assertNotNull(problemDetail.getTitle());
+                    assertFalse(problemDetail.getTitle().isBlank());
                 });
     }
 
@@ -154,8 +156,10 @@ public class PromptControllerTest {
                     ProblemDetail problemDetail = objectMapper.readValue(result.getResponse().getContentAsString(), ProblemDetail.class);
                     assertNotNull(problemDetail);
                     assertEquals(HttpStatus.INTERNAL_SERVER_ERROR.value(), problemDetail.getStatus());
-                    assertEquals("Something wrong happened", problemDetail.getDetail());
-                    assertEquals("Unexpected Error", problemDetail.getTitle());
+                    assertNotNull(problemDetail.getDetail());
+                    assertFalse(problemDetail.getDetail().isBlank());
+                    assertNotNull(problemDetail.getTitle());
+                    assertFalse(problemDetail.getTitle().isBlank());
                 });
         verify(promptService, times(1)).getResponse(any(PromptRequest.class));
     }
@@ -215,7 +219,8 @@ public class PromptControllerTest {
                     assertEquals(HttpStatus.BAD_REQUEST.value(), problemDetail.getStatus());
                     assertNotNull(problemDetail.getDetail());
                     assertFalse(problemDetail.getDetail().isBlank());
-                    assertEquals("Could not parse response", problemDetail.getTitle());
+                    assertNotNull(problemDetail.getTitle());
+                    assertFalse(problemDetail.getTitle().isBlank());
                 });
         verify(promptService, times(1)).getResponse(any(PromptRequest.class));
     }

--- a/src/test/java/pl/sgorski/Tagger/service/AiServiceTest.java
+++ b/src/test/java/pl/sgorski/Tagger/service/AiServiceTest.java
@@ -14,6 +14,7 @@ import org.springframework.ai.chat.model.Generation;
 import org.springframework.ai.chat.prompt.Prompt;
 import org.springframework.ai.openai.OpenAiChatModel;
 import org.springframework.ai.retry.NonTransientAiException;
+import org.springframework.context.MessageSource;
 import org.springframework.web.client.RestClientException;
 import pl.sgorski.Tagger.dto.PromptResponse;
 import pl.sgorski.Tagger.exception.AiParsingException;
@@ -31,6 +32,9 @@ public class AiServiceTest {
 
     @Mock
     private ObjectMapper objectMapper;
+
+    @Mock
+    private MessageSource messageSource;
 
     @InjectMocks
     private AiService aiService;

--- a/src/test/java/pl/sgorski/Tagger/service/ClothesServiceTest.java
+++ b/src/test/java/pl/sgorski/Tagger/service/ClothesServiceTest.java
@@ -5,6 +5,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.MessageSource;
 import pl.sgorski.Tagger.dto.ClothesRequest;
 import pl.sgorski.Tagger.dto.PromptRequest;
 import pl.sgorski.Tagger.dto.PromptResponse;
@@ -18,6 +19,9 @@ public class ClothesServiceTest {
 
     @Mock
     private AiService aiService;
+
+    @Mock
+    private MessageSource messageSource;
 
     @InjectMocks
     private ClothesService clothesService;

--- a/src/test/java/pl/sgorski/Tagger/service/ElectronicsServiceTest.java
+++ b/src/test/java/pl/sgorski/Tagger/service/ElectronicsServiceTest.java
@@ -5,6 +5,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.MessageSource;
 import pl.sgorski.Tagger.dto.ElectronicsRequest;
 import pl.sgorski.Tagger.dto.PromptRequest;
 import pl.sgorski.Tagger.dto.PromptResponse;
@@ -18,6 +19,9 @@ public class ElectronicsServiceTest {
 
     @Mock
     private AiService aiService;
+
+    @Mock
+    private MessageSource messageSource;
 
     @InjectMocks
     private ElectronicsService electronicsService;


### PR DESCRIPTION
# Pull Request

## Description
Responds can be in every language that OpenAI supports.

## Changes
- Added support for other languages in prompt response
- Added errors messages in `pl` and `en`
- Locale resolver by `Accept-Language` header
- Added simple GraphQL exception handler
- Upgraded prompt resolver tests
